### PR TITLE
Fix code scanning alert #36: Disabling certificate validation

### DIFF
--- a/spec/chromium-spec.ts
+++ b/spec/chromium-spec.ts
@@ -28,7 +28,11 @@ describe('reporting api', () => {
     // The Reporting API only works on https with valid certs. To dodge having
     // to set up a trusted certificate, hack the validator.
     session.defaultSession.setCertificateVerifyProc((req, cb) => {
-      cb(0);
+      if (req.errorCode === 0) {
+        cb(0);
+      } else {
+        cb(-3); // -3 means the certificate is not trusted
+      }
     });
 
     const options = {
@@ -39,7 +43,7 @@ describe('reporting api', () => {
         fs.readFileSync(path.join(certPath, 'intermediateCA.pem'))
       ],
       requestCert: true,
-      rejectUnauthorized: false
+      rejectUnauthorized: true
     };
 
     const server = https.createServer(options, (req, res) => {


### PR DESCRIPTION
Fixes [https://github.com/aka2024/electron/security/code-scanning/36](https://github.com/aka2024/electron/security/code-scanning/36)

_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
